### PR TITLE
fix(site): version immutable stylesheet

### DIFF
--- a/content/components/blog-header.md
+++ b/content/components/blog-header.md
@@ -8,7 +8,7 @@
     <meta content='initial-scale=1.0,width=device-width' name='viewport' />
     <meta content='#131516' name='theme-color' />
     <meta http-equiv='content-language' content='en-us,fr'>
-    <link rel="stylesheet" href="/assets/style.css">
+    <link rel="stylesheet" href="/assets/style.css?v=0551df31f10a">
     <link rel='stylesheet' href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.9.0/build/styles/github-dark.min.css">
     <title>sanix | %s</title>
     <style>img{width: 100%;}pre{background: rgb(24, 27, 28);border: 1px solid white;padding: 0px!important; border-radius: 5px;font-size: auto;box-shadow: 0 3px 6px rgba(0,0,0,0.16), 0 3px 6px rgba(0,0,0,0.23);}</style>

--- a/content/components/header.md
+++ b/content/components/header.md
@@ -7,7 +7,7 @@
         <meta content='initial-scale=1.0,width=device-width' name='viewport' />
         <meta content="#131516" name="theme-color" />
         <meta http-equiv="content-language" content="en-us,fr"/>
-        <link rel="stylesheet" href="/assets/style.css">
+        <link rel="stylesheet" href="/assets/style.css?v=0551df31f10a">
         <title>sanix blog</title>
         <style>article{margin: 0px} article img { width: 100%; max-height: 10em; object-fit: cover; }</style>
         <meta property="og:url" content="https://sanixdk.xyz/" />

--- a/docs/USER_STORIES.md
+++ b/docs/USER_STORIES.md
@@ -30,6 +30,8 @@ current intended behavior and are exercised by `make e2e`.
 - As an A, top-level Markdown should receive the shared header and footer.
 - Blog posts and nested project pages should receive the metadata-aware blog
   header, comment footer, and shared footer.
+- Shared headers should reference a content-versioned stylesheet so immutable
+  edge caches cannot keep serving an older layout.
 - As an M, each content Markdown file should produce a matching HTML file
   under `public/`.
 

--- a/scripts/e2e/stories.json
+++ b/scripts/e2e/stories.json
@@ -40,12 +40,14 @@
     "fallback": {
       "checks": [
         {"name": "about_has_skip_link", "url": "/about", "regex": "<a [^>]*class=['\"]skip['\"]", "min": 1},
+        {"name": "about_has_versioned_stylesheet", "url": "/about", "regex": "/assets/style\\.css\\?v=0551df31f10a", "min": 1},
         {"name": "about_has_home_link", "url": "/about", "regex": "href=['\"]/['\"]", "min": 1},
         {"name": "about_has_blogs_link", "url": "/about", "regex": "href=['\"]/blogs/['\"]", "min": 1},
         {"name": "about_has_projects_link", "url": "/about", "regex": "href=['\"]/projects/['\"]", "min": 1},
         {"name": "about_has_about_link", "url": "/about", "regex": "href=['\"]/about['\"]", "min": 1},
         {"name": "post_has_giscus_ref", "url": "/blogs/i-added-a-brain-to-my-fridge-it-backfired-hard-1-3", "regex": "giscus\\.app", "min": 1},
         {"name": "post_has_main_id", "url": "/blogs/i-added-a-brain-to-my-fridge-it-backfired-hard-1-3", "regex": "id=['\"]main['\"]", "min": 1},
+        {"name": "post_has_versioned_stylesheet", "url": "/blogs/i-added-a-brain-to-my-fridge-it-backfired-hard-1-3", "regex": "/assets/style\\.css\\?v=0551df31f10a", "min": 1},
         {"name": "post_has_skip_link", "url": "/blogs/i-added-a-brain-to-my-fridge-it-backfired-hard-1-3", "regex": "<a [^>]*class=['\"]skip['\"]", "min": 1}
       ]
     }


### PR DESCRIPTION
## Summary

- append the generated stylesheet content hash to both shared header links
- bypass the stale one-year immutable edge-cache entry after deployment
- cover top-level and blog-post templates in the component E2E story

## Validation

- complete `make e2e`: 34 passed, 0 failed, 4 intentional skips
- version value matches the tracked generated stylesheet SHA-256 prefix
- no generated HTML is tracked
